### PR TITLE
pass the root_url through to the actual host

### DIFF
--- a/js_host/host.py
+++ b/js_host/host.py
@@ -30,6 +30,7 @@ if res and res.json() == status:
     host = JSHost(
         status=status,
         config_file=config_file,
+        root_url = root_url
     )
 
     host.connect()


### PR DESCRIPTION
Unless I am missing something I think this line of code needs be there in order for the host to actually respect the `ROOT_URL` setting.

In any case, correct me if I am wrong, but when I setup a Varnish cache in front of `js-host` this was necessary to make the Python process actually call the correct endpoint.